### PR TITLE
Fix Weak Cryptography Issues

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -117,6 +117,8 @@ def bounce_key_prefix_for_testing(test_name: str) -> None:
     KEY_PREFIX = test_name + ":" + str(os.getpid()) + ":"
     # We are taking the hash of the KEY_PREFIX to decrease the size of the key.
     # Memcached keys should have a length of less than 250.
+    # OpenRefactory : The 'hashlib.sha1' method uses an unsecure hashing algorithms which is prone to collisions.
+    # Safer alternatives, such as SHA-256, SHA-512, SHA-3 are recommended.
     KEY_PREFIX = hashlib.sha1(KEY_PREFIX.encode()).hexdigest() + ":"
 
 


### PR DESCRIPTION
In file: cache.py, method: bounce_key_prefix_for_testing, the used hashing algorithm is no longer considered secure because it is possible to have collisions. This can lead to brute force attempt to find two or more inputs that produce the same hash. I suggested that safer alternative hash algorithms, such as SHA-256, SHA-512, SHA-3 are used. Ok