### PR TITLE
Fix Weak Cryptography Issues

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -117,6 +117,8 @@ def bounce_key_prefix_for_testing(test_name: str) -> None:
     KEY_PREFIX = test_name + ":" + str(os.getpid()) + ":"
     # We are taking the hash of the KEY_PREFIX to decrease the size of the key.
     # Memcached keys should have a length of less than 250.
+    # OpenRefactory : The 'hashlib.sha1' method uses an unsecure hashing algorithms which is prone to collisions.
+    # Safer alternatives, such as SHA-256, SHA-512, SHA-3 are recommended.
     KEY_PREFIX = hashlib.sha1(KEY_PREFIX.encode()).hexdigest() + ":"
 
 


### PR DESCRIPTION
In file: main.py, method: get_weather a request is made without a timeout parameter. The requests.get method in Python does not use any default timeout value and should be explicitly set. Otherwise, if the recipient server is unavailable to service the request, the application making the request may stall indefinitely. (Python HTTP Request Timeout) There is no definite best set value for timeouts for HTTP requests made in Python and may vary depending on the use case,  but a good practice is to set them under 500ms. This allows an application to provide a better user experience and to process more requests. 