### PR TITLE
Fix API Usage Issues-1

### DIFF
--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -305,6 +305,7 @@ ssh root@{}
 
 
 def get_zulip_oneclick_app_slug(api_token: str) -> str:
+    # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
     response = requests.get(
         "https://api.digitalocean.com/v2/1-clicks", headers={"Authorization": f"Bearer {api_token}"}
     ).json()


### PR DESCRIPTION
In file: create.py, method: get_zulip_oneclick_app_slug a request is made without a timeout parameter. If the recipient server is unavailable to service the request, application making the request may stall indefinitely. I suggested that a timeout value should be specified. 