### PR TITLE
Fix API Usage Issues-2

### DIFF
--- a/tools/droplets/add_mentor.py
+++ b/tools/droplets/add_mentor.py
@@ -33,6 +33,7 @@ append_key = """\
 def get_mentor_keys(username: str) -> List[str]:
     url = f"https://api.github.com/users/{username}/keys"
 
+    # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
     r = requests.get(url)
     if r.status_code != 200:
         print("Cannot connect to GitHub...")


### PR DESCRIPTION
In file: add_mentor.py, method: get_mentor_keys a request is made without a timeout parameter. If the recipient server is unavailable to service the request, application making the request may stall indefinitely. I suggested that a timeout value should be specified. 