### PR TITLE
Fix Security Misconfiguration Issues-3

### DIFF
--- a/zerver/views/development/cache.py
+++ b/zerver/views/development/cache.py
@@ -1,4 +1,4 @@
-import os
+import o
 
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -11,7 +11,7 @@ from zerver.models import clear_client_cache, flush_per_request_caches
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../")
 
 # This is used only by the Puppeteer tests to clear all the cache after each run.
-@csrf_exempt
+# OpenRefactory Warning: CSRF protection should not be disabled on a view
 @require_post
 def remove_caches(request: HttpRequest) -> HttpResponse:
     cache = get_cache_backend(None)


### PR DESCRIPTION
In file: cache.py, method: remove_caches, Cross Site Request Forgery protection is exempted on a view using a decorator. A user of this application may be tricked by an attacker to click on a link or visit a malicious website. I removed the decorator responsible for CSRF exemption. 