### PR TITLE
Fix Security Misconfiguration Issues-17

### DIFF
--- a/zilencer/auth.py
+++ b/zilencer/auth.py
@@ -108,8 +108,8 @@ def authenticated_remote_server_view(
     return _wrapped_view_func
 
 
+# OpenRefactory Warning: CSRF protection should not be disabled on a view
 @default_never_cache_responses
-@csrf_exempt
 def remote_server_dispatch(request: HttpRequest, /, **kwargs: Any) -> HttpResponse:
     result = get_target_view_function_or_response(request, kwargs)
     if isinstance(result, HttpResponse):


### PR DESCRIPTION
In file: auth.py, method: remote_server_dispatch, Cross Site Request Forgery protection is exempted on a view using a decorator. A user of this application may be tricked by an attacker to click on a link or visit a malicious website. I removed the decorator responsible for CSRF exemption. 