### PR TITLE
Fix Security Misconfiguration Issues-10

### DIFF
--- a/zerver/views/unsubscribe.py
+++ b/zerver/views/unsubscribe.py
@@ -70,7 +70,7 @@ email_unsubscribers = {
 }
 
 # Login NOT required. These are for one-click unsubscribes.
-@csrf_exempt
+# OpenRefactory Warning: CSRF protection should not be disabled on a view
 def email_unsubscribe(request: HttpRequest, email_type: str, confirmation_key: str) -> HttpResponse:
     if email_type in email_unsubscribers:
         display_name, unsubscribe_function = email_unsubscribers[email_type]


### PR DESCRIPTION
In file: unsubscribe.py,  Cross Site Request Forgery protection is exempted on a view using a decorator. A user of this application may be tricked by an attacker to click on a link or visit a malicious website. I removed the decorator responsible for CSRF exemption. 