### PR TITLE
Fix Security Misconfiguration Issues-11

### DIFF
--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -162,7 +162,7 @@ def make_zoom_video_call(request: HttpRequest, user: UserProfile) -> HttpRespons
     return json_success(request, data={"url": res.json()["join_url"]})
 
 
-@csrf_exempt
+# OpenRefactory Warning: CSRF protection should not be disabled on a view
 @require_POST
 @has_request_variables
 def deauthorize_zoom_user(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
In file: video_calls.py, method: deauthorize_zoom_user, Cross Site Request Forgery protection is exempted on a view using a decorator. A user of this application may be tricked by an attacker to click on a link or visit a malicious website. I removed the decorator responsible for CSRF exemption. 