### PR TITLE
Fix Security Misconfiguration Issues-12

### DIFF
--- a/zerver/management/commands/process_queue.py
+++ b/zerver/management/commands/process_queue.py
@@ -50,6 +50,7 @@ class Command(BaseCommand):
     help = "Runs a queue processing worker"
 
     def handle(self, *args: Any, **options: Any) -> None:
+        # OpenRefactory Warning: Logger configuration can lead to security vulnerabilities.
         logging.basicConfig()
         logger = logging.getLogger("process_queue")
 


### PR DESCRIPTION
In file: process_queue.py, the application either disables the logging operation or chooses the default logging configuration. I suggested that the logger configuration should not be ignored. Details such as determining whether to store warnings, info, or error messages, deciding which details to store, etc., should be specified in detail. 